### PR TITLE
disable construction from streams in python and mark interface as experimental

### DIFF
--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -13,6 +13,8 @@
 #include "MultithreadedMolSupplier.h"
 namespace RDKit {
 
+//! This class is still a bit experimental and the public API may change
+//! in future releases.
 class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
     : public MultithreadedMolSupplier {
  public:

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -12,6 +12,8 @@
 #define MULTITHREADED_SMILES_MOL_SUPPLIER
 #include "MultithreadedMolSupplier.h"
 namespace RDKit {
+//! This class is still a bit experimental and the public API may change
+//! in future releases.    
 class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
     : public MultithreadedMolSupplier {
  public:

--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -82,7 +82,7 @@ add_pytest(pyTestSGroups
 if (RDK_TEST_MULTITHREADED)
   add_pytest(pyTestThreads
            ${CMAKE_CURRENT_SOURCE_DIR}/testThreads.py)
-	add_pytest(pyTestSGroups
+	add_pytest(pyTestMultithreadedMolSupplier
          ${CMAKE_CURRENT_SOURCE_DIR}/testMultithreadedMolSupplier.py)
 endif (RDK_TEST_MULTITHREADED)
 

--- a/Code/GraphMol/Wrap/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MultithreadedSDMolSupplier.cpp
@@ -66,7 +66,7 @@ std::string multiSdsDocStr =
     - sizeOutputQueue: (optional) size of output/writer queue. Defaults to 5.\n\
 \n";
 
-MultithreadedSDMolSupplier* MTMolSupplCompressedStream(
+MultithreadedSDMolSupplier* MTMolSupplStream(
     python::object& input, bool sanitize = true, bool removeHs = true,
     bool strictParsing = true, unsigned int numWriterThreads = 1,
     size_t sizeInputQueue = 5, size_t sizeOutputQueue = 5) {
@@ -81,8 +81,8 @@ MultithreadedSDMolSupplier* MTMolSupplCompressedStream(
 struct multiSDMolSup_wrap {
   static void wrap() {
     python::def(
-        "openWithCompressedStream", MTMolSupplCompressedStream,
-        "Returns MultithreadedSDMolSupplier object with compressed stream",
+        "SDMolSupplierFromStream", MTMolSupplStream,
+        "Returns MultithreadedSDMolSupplier object constructed from a file object or stream",
         (python::arg("fileobj"), python::arg("sanitize") = true,
          python::arg("removeHs") = true, python::arg("strictParsing") = true,
          python::arg("numWriterThreads") = 1, python::arg("sizeInputQueue") = 5,

--- a/Code/GraphMol/Wrap/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MultithreadedSDMolSupplier.cpp
@@ -65,7 +65,8 @@ std::string multiSdsDocStr =
 \n\
     - sizeOutputQueue: (optional) size of output/writer queue. Defaults to 5.\n\
 \n";
-
+#if 0
+// FIX: disabled until we figure out how to make this stable
 MultithreadedSDMolSupplier* MTMolSupplStream(
     python::object& input, bool sanitize = true, bool removeHs = true,
     bool strictParsing = true, unsigned int numWriterThreads = 1,
@@ -77,9 +78,11 @@ MultithreadedSDMolSupplier* MTMolSupplStream(
       sizeInputQueue, sizeOutputQueue);
   return sup;
 }
-
+#endif
 struct multiSDMolSup_wrap {
   static void wrap() {
+#if 0
+    // FIX: disabled until we make it stable and figure out an API that we're happy with
     python::def(
         "SDMolSupplierFromStream", MTMolSupplStream,
         "Returns MultithreadedSDMolSupplier object constructed from a file object or stream",
@@ -89,6 +92,7 @@ struct multiSDMolSup_wrap {
          python::arg("sizeOutputQueue") = 5),
         python::with_custodian_and_ward_postcall<
             0, 1, python::return_value_policy<python::manage_new_object>>());
+#endif
 
     python::class_<MultithreadedSDMolSupplier, boost::noncopyable>(
         "MultithreadedSDMolSupplier", multiSDMolSupplierClassDoc.c_str(),

--- a/Code/GraphMol/Wrap/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MultithreadedSDMolSupplier.cpp
@@ -29,6 +29,8 @@ namespace RDKit {
 
 std::string multiSDMolSupplierClassDoc =
     "A class which concurrently supplies molecules from a text file.\n\
+  Please note that this class is still a bit experimental and the API may\n\
+  change in future releases.\n\
 \n\
   Usage examples:\n\
 \n\

--- a/Code/GraphMol/Wrap/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/MultithreadedSmilesMolSupplier.cpp
@@ -27,6 +27,8 @@ namespace python = boost::python;
 namespace RDKit {
 std::string multiSmilesMolSupplierClassDoc =
     "A class which concurrently supplies molecules from a text file.\n\
+  Please note that this class is still a bit experimental and the API may\n\
+  change in future releases.\n\
 \n\
   Usage examples:\n\
 \n\

--- a/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
+++ b/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
@@ -56,7 +56,15 @@ class TestCase(unittest.TestCase):
                 i += 1
         self.assertTrue(len(molNames) == i)
         self.assertTrue(sorted(confusedMolNames) == sorted(molNames))
-
+        
+    # NOTE these are disabled until we rewrite the code to construct a 
+    #      MultithreadedSDMolSupplier from a python stream
+    @unittest.skip("Skipping construction from stream")
+    def testMultiSDMolSupplierFromStream(self):
+        fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol',
+                             'FileParsers', 'test_data', 'NCI_aids_few.sdf')
+        molNames = ["48", "78", "128", "163", "164", "170", "180", "186",
+            "192", "203", "210", "211", "213", "220", "229", "256"]
         # try opening with streambuf
         inf = open(fileN,'rb')
         if(inf):

--- a/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
+++ b/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
@@ -3,7 +3,7 @@ import gzip
 from rdkit import RDConfig, rdBase
 from rdkit import Chem
 from rdkit import __version__
-
+import sys
 
 class TestCase(unittest.TestCase):
     def testMultiSmiMolSupplier(self):
@@ -58,15 +58,30 @@ class TestCase(unittest.TestCase):
         self.assertTrue(sorted(confusedMolNames) == sorted(molNames))
 
         # try opening with streambuf
-        fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
-                         'NCI_aids_few.sdf.gz') 
-       # try opening with gzip
-        inf = gzip.open(fileN)
+        inf = open(fileN,'rb')
         if(inf):
-          gSup = Chem.openWithCompressedStream(inf)
+          gSup = Chem.SDMolSupplierFromStream(inf)
           confusedMolNames = []
           i = 0
           for mol in gSup:
+            # print("!!",i,file=sys.stderr);sys.stderr.flush()
+            if(mol):
+              confusedMolNames.append(mol.GetProp("_Name"))
+              i += 1
+          self.assertTrue(len(molNames) == i)
+          self.assertTrue(sorted(confusedMolNames) == sorted(molNames))
+        #   print("done!",file=sys.stderr);sys.stderr.flush()
+        # try opening with streambuf
+        fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                         'NCI_aids_few.sdf.gz') 
+        # try opening with gzip
+        inf = gzip.open(fileN)
+        if(inf):
+          gSup = Chem.SDMolSupplierFromStream(inf)
+          confusedMolNames = []
+          i = 0
+          for mol in gSup:
+            # print("!",i,file=sys.stderr);sys.stderr.flush()
             if(mol):
               confusedMolNames.append(mol.GetProp("_Name"))
               i += 1


### PR DESCRIPTION
There were some persistent heisenbugs with using the code that constructs a multithreaded supplier from a python stream on windows and the mac, so I've disabled that interface until we have time to really test the hell out of it.

I also marked the new multithreaded classes as experimental in case we want/need to change the public API after doing more testing